### PR TITLE
Improve site configuration

### DIFF
--- a/src/act/client/client2arc.py
+++ b/src/act/client/client2arc.py
@@ -12,13 +12,13 @@ import signal
 import sys
 import traceback
 import time
-import json
 
-import clientdb
 import act.arc.aCTDBArc as aCTDBArc
 import act.common.aCTConfig as aCTConfig
 import act.common.aCTLogger as aCTLogger
 import act.common.aCTSignal as aCTSignal
+import act.client.config as config
+import act.client.clientdb as clientdb
 
 
 class Client2Arc(object):
@@ -155,21 +155,13 @@ class Client2Arc(object):
             limit=num
         )
         for job in jobs:
-            # get path to sites config
-            if 'ACTCONFIGARC' in os.environ:
-                binpath = os.path.dirname(os.environ['ACTCONFIGARC'])
-                confpath = os.path.join(binpath, 'sites.json')
-            else:
-                confpath = '/etc/act/sites.json'
-
             # get cluster list from config
+            clusterlist = ""
+            sites = config.readSites()
             clusterlist = ''
-            with open(confpath, 'r') as f:
-                sites = json.loads(f.read())
-                clusterlist = ''
-                for site in sites['sites'][job['siteName']]:
-                    clusterlist += site + ','
-                clusterlist = clusterlist.rstrip(',')
+            for cluster in sites[job['siteName']]:
+                clusterlist += cluster + ','
+            clusterlist = clusterlist.rstrip(',')
 
             # get job description, needed for setting priority
             jobdesc = self.arcdb.getArcJobDescription(job['jobdesc'])

--- a/src/act/client/config.py
+++ b/src/act/client/config.py
@@ -1,0 +1,40 @@
+"""
+This module implements functions that read configuration.
+"""
+
+
+import json
+import os
+
+
+def readSites():
+    """
+    Return dictionary of sites.
+
+    Returns:
+        A dictionary where key is a site name and value is a list of clusters
+        (strings).
+    """
+    SITE_FILENAME = "sites.json"
+    confpath = ""
+    # first, try to get config from virtual environment
+    if not confpath and "VIRTUAL_ENV" in os.environ:
+        confpath = os.path.join(os.environ["VIRTUAL_ENV"], "etc", "act", SITE_FILENAME)
+        if not os.path.isfile(confpath):
+            confpath = ""
+    # try to get from etc if not in virtual environemnt
+    if not confpath:
+        confpath = os.path.join(os.sep, "etc", "act", SITE_FILENAME)
+        if not os.path.isfile(confpath):
+            confpath = ""
+    # try to get from pwd
+    if not confpath:
+        confpath = SITE_FILENAME
+        if not os.path.isfile(confpath):
+            # TODO: is it necessary to create a dedicated exception?
+            raise Exception("error: no site configuration found")
+
+    with open(confpath, "r") as f:
+        sites = json.loads(f.read())
+
+    return sites

--- a/src/act/client/jobmgr.py
+++ b/src/act/client/jobmgr.py
@@ -5,7 +5,6 @@ This is a module that provides job management functionality.
 
 import logging
 import shutil
-import json
 import os
 import sys
 
@@ -13,6 +12,7 @@ import arc
 import act.arc.aCTDBArc as aCTDBArc
 import act.common.aCTConfig as aCTConfig
 import act.client.clientdb as clientdb
+import act.client.config as config
 from act.client.errors import *
 
 
@@ -664,24 +664,16 @@ def checkSite(siteName, confpath='/etc/act/sites.json'):
     Raises:
         NoSuchSiteError: Site is not in configuration.
     """
-    #conf = aCTConfig.aCTConfig()
-    #if siteName in conf.get(['sites']):
-    #    return
-    #else:
-    #    NoSuchSiteError(siteName)
-    if 'ACTCONFIGARC' in os.environ:
-        binpath = os.path.dirname(os.environ['ACTCONFIGARC'])
-        confpath = os.path.join(binpath, 'sites.json') # HARDCODED
     try:
-        with open(confpath, 'r') as f:
-            sites = json.loads(f.read())
-            for site in sites['sites'].keys():
-                if site == siteName:
-                    return
-            raise NoSuchSiteError(siteName)
-    except IOError, ValueError:
+        sites = config.readSites()
+        for site in sites:
+            if site == siteName:
+                return
+    except Exception:
         logger.exception('Problem reading configuration')
         raise
+
+    raise NoSuchSiteError(siteName)
 
 
 def getIDsFromList(listStr):

--- a/src/act/client/sites.json
+++ b/src/act/client/sites.json
@@ -1,6 +1,3 @@
 {
-	"sites": 
-		{
-			"default": ["https://pikolit.ijs.si"]
-		}
+	"default": ["https://pikolit.ijs.si/batch"]
 }


### PR DESCRIPTION
This improves site configuration. Site names are now keys of the root object. A value is still a list of cluster names. Also, sites.json path is not relative to ACTCONFIGARC anymore. The paths are now searched in the same order and location as described in the README.md:

1. $VIRTUAL_ENV/etc/act/
2. /etc/act/
3. ./