### PR TITLE
Lock required version of gunicorn

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(name='aCT',
 
         'pyopenssl',
         'flask',
-        'gunicorn',
+        'gunicorn==19.*',           # Python 2 is not supported in >= 20.*
         'sqlalchemy'
       ],
       entry_points={


### PR DESCRIPTION
Gunicorn above version 19 does not support Python 2 anymore.