### PR TITLE
fix run number in metadata extraction script 

### DIFF
--- a/src/act/ldmx/scripts/ldmx-simprod-rte-helper.py
+++ b/src/act/ldmx/scripts/ldmx-simprod-rte-helper.py
@@ -99,7 +99,7 @@ def collect_from_json( infile ):
     if 'runNumber' in mjson['sequence'][0] :
         config_dict['RunNumber'] = mjson['sequence'][0]['runNumber']
     elif 'run' in mjson :
-        config_dict['RunNumber'] = mjson['runNumber']
+        config_dict['RunNumber'] = mjson['run']
     else :
         logger.error('RunNumber is not set in %s. Job aborted.', infile)
         sys.exit(1)

--- a/src/act/ldmx/scripts/ldmx-simprod-rte-helper.py
+++ b/src/act/ldmx/scripts/ldmx-simprod-rte-helper.py
@@ -98,6 +98,8 @@ def collect_from_json( infile ):
 
     if 'runNumber' in mjson['sequence'][0] :
         config_dict['RunNumber'] = mjson['sequence'][0]['runNumber']
+    elif 'run' in mjson :
+        config_dict['RunNumber'] = mjson['runNumber']
     else :
         logger.error('RunNumber is not set in %s. Job aborted.', infile)
         sys.exit(1)


### PR DESCRIPTION
This completes the fix relating to the changed run number parameter naming convention and ownership, by including the new structure in the parameter dump file.