### PR TITLE
handle no local output file

### DIFF
--- a/src/act/ldmx/aCTLDMXStatus.py
+++ b/src/act/ldmx/aCTLDMXStatus.py
@@ -119,7 +119,7 @@ class aCTLDMXStatus(aCTLDMXProcess):
 
             # Check if there is an arc job
             columns = ['id']
-            arcjob = self.dbarc.getArcJobInfo(job['arcjobid'], columns)
+            arcjob = self.dbarc.getArcJobInfo(job['arcjobid'], columns) if job['arcjobid'] else None
             if arcjob:
                 self.log.info(f"Cancelling arc job {arcjob['id']}")
                 select = "id='{}'".format(job['arcjobid'])

--- a/src/act/ldmx/scripts/ldmx-simprod-rte-helper.py
+++ b/src/act/ldmx/scripts/ldmx-simprod-rte-helper.py
@@ -201,16 +201,14 @@ def job_starttime(starttime_f='.ldmx.job.starttime'):
 
 def set_remote_output(conf_dict, meta):
     # Check for remote location and construct URL
-    # GRID_GLOBAL_JOBHOST is available from ARC 6.8
-    cehost = os.environ.get('GRID_GLOBAL_JOBHOST')
-    if 'FinalOutputDestination' in conf_dict and 'FinalOutputBasePath' in conf_dict \
-      and cehost not in conf_dict.get('NoUploadSites', '').split(','):
+    if 'FinalOutputDestination' in conf_dict and 'FinalOutputBasePath' in conf_dict:
         pfn = conf_dict['FinalOutputBasePath']
         while pfn.endswith('/'):
             pfn = pfn[:-1]
-        pfn += '/{Scope}/v{DetectorVersion}/{BeamEnergy}GeV/{BatchID}/mc_{SampleId}_run{RunNumber}_t{FileCreationTime}.root'.format(**meta)
+        pfn += '/{Scope}/v{DetectorVersion}/{BeamEnergy}GeV/{BatchID}/{name}'.format(**meta)
         meta['remote_output'] = {'rse': conf_dict['FinalOutputDestination'],
                                  'pfn': pfn}
+        meta['DataLocation'] = pfn
         # Add to ARC output list
         with open('output.files', 'w') as f:
             f.write('{} {}'.format(conf_dict['FileName'], pfn))
@@ -244,13 +242,23 @@ def collect_meta(conf_dict, json_file):
         logger.error('Output file {} does not exist!'.format(conf_dict.get('FileName', '')))
         return meta
 
-    data_location = os.environ['LDMX_STORAGE_BASE']
-    data_location += '/ldmx/mc-data/v{DetectorVersion}/{BeamEnergy}GeV/{BatchID}/mc_{SampleId}_run{RunNumber}_t{FileCreationTime}.root'.format(**meta)
-    meta['DataLocation'] = data_location
+    meta['name'] = 'mc_{SampleId}_run{RunNumber}_t{FileCreationTime}.root'.format(**meta)
+    set_remote_output(conf_dict, meta)
+    if os.environ.get('KEEP_LOCAL_OUTPUT'):
+        data_location = os.environ['LDMX_STORAGE_BASE']
+        data_location += '/ldmx/mc-data/v{DetectorVersion}/{BeamEnergy}GeV/{BatchID}/{name}'.format(**meta)
+        meta['local_replica'] = data_location
+        if 'DataLocation' in meta:
+            meta['DataLocation'] = ','.join([meta['DataLocation'], data_location])
+        else:
+            meta['DataLocation'] = data_location
+
+    if not meta.get('DataLocation'):
+        logger.error('No local or remote output location for output file, file will not be registered in Rucio')
+        return meta
 
     # Rucio metadata
     meta['scope'] = meta['Scope']
-    meta['name'] = os.path.basename(data_location)
     meta['datasetscope'] = meta['Scope']
     meta['datasetname'] = meta['BatchID']
     meta['containerscope'] = meta['Scope']
@@ -259,7 +267,6 @@ def collect_meta(conf_dict, json_file):
     meta['bytes'] = os.stat(conf_dict['FileName']).st_size
     (meta['md5'], meta['adler32']) = calculate_md5_adler32_checksum(conf_dict['FileName'])
 
-    set_remote_output(conf_dict, meta)
     return meta
 
 def get_parser():
@@ -299,9 +306,8 @@ if __name__ == '__main__':
         print_eval(conf_dict)
     elif cmd_args.action == 'collect-metadata':
         meta = collect_meta(conf_dict, cmd_args.metaDump)
-        if 'DataLocation' not in meta:
-            sys.exit(1)
-        print('export FINALOUTPUTFILE="{DataLocation}"'.format(**meta))
+        if 'local_replica' in meta:
+            print('export FINALOUTPUTFILE="{local_replica}"'.format(**meta))
         with open(cmd_args.json_metadata, 'w') as meta_f:
             json.dump(meta, meta_f)
 

--- a/src/act/ldmx/scripts/ldmxsim.sh
+++ b/src/act/ldmx/scripts/ldmxsim.sh
@@ -51,20 +51,18 @@ if [ $RET -ne 0 ]; then
 fi
 
 echo -e "\nSingularity exited normally, proceeding with post-processing...\n"
-
+export KEEP_LOCAL_OUTPUT=1
 # Post processing to extract metadata for rucio
 eval $( python ldmx-simprod-rte-helper.py -j rucio.metadata -c ldmxproduction.config collect-metadata )
-if [ -z "$FINALOUTPUTFILE" ]; then
-  echo "Post-processing script failed!"
-  exit 1
-fi
+if [ ! -z "$FINALOUTPUTFILE" ]; then
 
-echo "Copying $OUTPUTDATAFILE to $FINALOUTPUTFILE"
-mkdir -p "${FINALOUTPUTFILE%/*}"
-cp "$OUTPUTDATAFILE" "$FINALOUTPUTFILE"
-if [ $? -ne 0 ]; then
-  echo "Failed to copy output to final destination"
-  exit 1
+  echo "Copying $OUTPUTDATAFILE to $FINALOUTPUTFILE"
+  mkdir -p "${FINALOUTPUTFILE%/*}"
+  cp "$OUTPUTDATAFILE" "$FINALOUTPUTFILE"
+  if [ $? -ne 0 ]; then
+    echo "Failed to copy output to final destination"
+    exit 1
+  fi
 fi
 
 # Success


### PR DESCRIPTION
Hi @bryngemark can you take a look at these changes, especially in the helper script? I have changed it to allow keeping either a local file, remote file or both. In the case of both then `DataLocation` will have the two locations separated by a comma. I set `KEEP_LOCAL_OUTPUT` just to test it, but this variable will eventually be set by the SIMPROD RTE.